### PR TITLE
Fix misplaced notes for Huberman Episode 13

### DIFF
--- a/episode 013 - The Science of Emotions & Relationships/epsiode 013 - key takeaways.md
+++ b/episode 013 - The Science of Emotions & Relationships/epsiode 013 - key takeaways.md
@@ -1,53 +1,19 @@
-# Key takeaway 1 : Dopamine, precursor to adrenaline
-Dopamine isn't just the molecule of reward and pleasure. It's the precursor to adrenaline in the body 
-and epinephrine in the brain. 
+Key takeaway 1 : Emotions shape our experience of life
+Almost all things that human experience go through the lens of emotions. Therefore, they are really important. However, it's also important to understand that emotions are subjective. Two people certainly don't have the same way of thinking about happinness. So emotions are important and complex.
 
-# Key takeaway 2 : The reward pathway : gas pedal and brake
-In the reward pathway, dopamine is the gas pedal. It's the things that gets us to be motivated to do something, to 
-engage into movement to achieve something, ...
+But even though they are complex, they can be understood and therefore there exists tools to leverage this understanding.
 
-There is also a brake in the reward pathway that is embodied by the prefrontal cortex. Animals don't have much of it. Humans have full of it. Without that brake, humans would be pure pleasure seeking animals. 
+Key takeaway 2 : Emotions are not born from one specific area in the brain
+Today, there are pretty good evidence (Lisa Fedmann Barrett) that emotions are not governed by one specific area in the brain (e.g. there is not one specific area that is responsible for the sad feeling as it was thought before).
 
-# Key takeway 3 : Food, sex, nicotine, cocaine
-Nicotine is increased respectively 50%, 100%, 150%, 1000% above baseline following food ingestion, sex act, nicotine and cocaine use. Now one understand why people become addict.
+However, it's clear that emotions are born from the brain AND the body. They arise because there are specific connections between areas of the brain and areas of the body.
 
-Now what is interesting is that the dopamine release above baseline can be increased before the consumption by just thinking about something. And that's normal since dopamine reward system was made for survival so trigger a desirable behaviour. Of course, just thinking about cocaine won't reach the 1000% increase. 
+Key takeway 3 : At first, there is anxiety
+When a baby comes into the world, he as no understanding of the world. He is pure interoception and has no exteroception.
 
-# Key takeaway 4 : Motivation & addiction : a story of pleasure and pain
-For every bit of pleasure (e.g. eating some delicious food), there is an equivalent bit of pain created (craving for the next bit of delicious food). 
+All he feels is anxiety. He does not understand pain, hunger, heat or cold. All he knows is that at some point he feels anxiety and responds to it by crying or cooing and then a caregiver answers to that agitation with a guess (give food, wrap in a blanket, change diaper, ...). So as a baby, you have the model that the world responds to your anxiety.
 
-Now the issue is that by pursuing the behavior, the pleasure will diminish but the pain will increase. And this implies that the role of dopamine is two-fold and one is more prevalent. Dopamine is involved in pleasure. At first. But then, afterwards, dopamine is involved in putting you into action for releasing the pain. For releasing the craving.
+And so little by little he will start considering the outside world as a way to calm his anxiety. Ok if I cry this much or that much, the outside world (caregiver) calms my anxiety. So this is the first foundation for human's emotional experience.
 
-# Key takeaway 5 : Satisfaction. Serotonin, prolactin; oxytocyn
-The counterpart to dopamine system is the serotonin system (also linked to oxytocyn & prolactin) which is called the here and now system. It allows you to enjoy the present and stops you from constantly project into the future and seek action. 
-
-And this system is also supported by the endogenous canabinoids that human make. And that's why THC and majijuana have those kind of calming down effects (one could say lethargic) because they bind to identical receptors. Also, this system is linked to forgetting. Hence why pot smokers have not good memory. 
-
-# Key takeaway 6 : Push & pull and balance
-In order to enjoy life, there must be a balance between the dopamine system and the serotonin system. If you are high on the dopaminergic pathway, you will always be in pursuit of something. That's good for achieving goals but not so good for enjoying life. Furthermore, some dopaminergic people can achieve their goals through manipulative ways and are therefore not good to be around.
-
-The contrary is also true. Being too far to the serotonin side gets you to be satisfied with what you have, which is good for enjoying life. But then impedes you reaching higher ceilings and goals, ... 
-
-# Key takeaway 7 : Prolactin puts the brake on the dopamin system
-Prolactine (and yes it's present in males) causes a crash in the dopamine system. It happens for example after sex. Prolactin is released and impedes the male from mating again. Now this varies from person to person and it varies depending on the context. Novelty (e.g. introduction of a new female) for example diminishes the prolactin effect. 
-
-# Key takeaway 8 : Extending the dopamine arc
-After a significant inflection in Dopamine, it's not unusual to feel a letdown. One can diminish that feeling by either not letting the dopamine spark too much or by extending the arc of dopamine cognitively. So for example remembering how great the trip was to whatever big achievement. 
-
-# Key takeaway 9 : Reward-prediction error : How to crash your dopamine system
-If you expect something to happen, your dopamine system ramps up in expectation. And if that something does not happen, you have a big reward-prediction error that will crash your dopamine system. 
-
-So never say maybe to a kid. Because he won't hear the word maybe and when comes the time to get the reward, he won't have it but its dopamine system predict it would have it. So ... big crash! (adults are the same by the way)
-
-# Key takeaway 10 : Viewing light late at night : how to do a middle finger to your dopamine system
-Viewing light in the middle of the night (so from 10pm to 4am) really puts a dent into the dopamine system. Therefore people who work late on their computers, ... are really impeding their dopamine system and therefore their drive, their ability to pursue achievements in the long term. 
-
-# Key takeaway 11 : Context switching is terrible for the brain
-For more information, read the book from Cal NewPort called deep work.
-
-# Key takeaway 12 : The most powerful dopamine release schedule comes from Las Vegas
-Gambling ! Gambling is the ultimate dopamine release schedule. Gambling addict will throw away their entire life for the hope of winning the next time.
-
-So the mechanism behind this is intermittent reinforcement. Meaning that you lost most of the time and sometimes you win. 
-
-How to leverage that so that one keeps going ? Keeps achieving its goals ? Reward yourself chaotically. Sometimes three times in a row after three achievements. Then not at all for 10 days in a row. This will keep the dopamine system in check and ensure you keep pursuing your goals in the long term and not feel too big of a dopamine crash. 
+Key takeaway 4 : Three questions to assess your emotional state
+What is your level of autonomic arousal (1 to 10), how are you feeling (good, bad,... the Valence in fact) and how much are you interoceptive or exteroceptive. Those are the three questions that one must answer to have a basis of his emotional state at a given point in time.


### PR DESCRIPTION
Thanks for providing these notes on the Huberman podcast.

I noticed there was a change to this file that caused its notes to be replaced with that of another episode.

It appears that this commit caused several files to be replaced with notes of 1 file: https://github.com/FenryrMKIII/huberman-podcast/commit/31090d54e7dd729179f9ab57ad29ef519faf03fb

It may be worth looking into that commit and undo-ing some of the changes.

---

Link to the corrected Ep13 notes I found: https://github.com/FenryrMKIII/huberman-podcast/blob/815f8d01890201a974dd248eac8af150c72d6fe5/episode%2013%20-%20The%20Science%20of%20Emotions%20%26%20Relationships/epsiode%2013%20-%20key%20takeaways.md

Linked to initial correct Ep13 commit: https://github.com/FenryrMKIII/huberman-podcast/commit/815f8d01890201a974dd248eac8af150c72d6fe5